### PR TITLE
require ocaml-migrate-parsetree >= 1.0

### DIFF
--- a/ppx_driver.opam
+++ b/ppx_driver.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ppx_core"
   "jbuilder"                {build & >= "1.0+beta12"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]
 descr: "


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/11471 .